### PR TITLE
Change to_html function to as_html!

### DIFF
--- a/lib/phoenix_markdown/engine.ex
+++ b/lib/phoenix_markdown/engine.ex
@@ -14,7 +14,7 @@ defmodule PhoenixMarkdown.Engine do
     try do
       file_path
         |> File.read!
-        |> Earmark.to_html
+        |> Earmark.as_html!
     rescue
       error ->
         reraise error, System.stacktrace


### PR DESCRIPTION
Earmark has deprecated to_html function in favor of as_html and as_html!.

This merge request just changes Earmark.to_html to Earmark.as_html!