### PR TITLE
Percent-decode server tags in URI's

### DIFF
--- a/lib/phoenix_markdown/engine.ex
+++ b/lib/phoenix_markdown/engine.ex
@@ -57,7 +57,7 @@ defmodule PhoenixMarkdown.Engine do
     smart_tag = ~r/&lt;%.*?%&gt;/
     markdown = Regex.replace(smart_tag, markdown, &HtmlEntities.decode/1)
 
-    uri_smart_tag = ~r/%3C%25+.*?%25%3E/
+    uri_smart_tag = ~r/%3C(%25)+.*?%25%3E/
     Regex.replace(uri_smart_tag, markdown, &URI.decode/1)
   end
 

--- a/lib/phoenix_markdown/engine.ex
+++ b/lib/phoenix_markdown/engine.ex
@@ -57,7 +57,7 @@ defmodule PhoenixMarkdown.Engine do
     smart_tag = ~r/&lt;%.*?%&gt;/
     markdown = Regex.replace(smart_tag, markdown, &HtmlEntities.decode/1)
 
-    uri_smart_tag = ~r/"%3C%25.*?%25%3E"/
+    uri_smart_tag = ~r/%3C%25+.*?%25%3E/
     Regex.replace(uri_smart_tag, markdown, &URI.decode/1)
   end
 

--- a/lib/phoenix_markdown/engine.ex
+++ b/lib/phoenix_markdown/engine.ex
@@ -55,7 +55,10 @@ defmodule PhoenixMarkdown.Engine do
   # --------------------------------------------------------
   defp do_restore_smart_tags(markdown, true) do
     smart_tag = ~r/&lt;%.*?%&gt;/
-    Regex.replace(smart_tag, markdown, &HtmlEntities.decode/1)
+    markdown = Regex.replace(smart_tag, markdown, &HtmlEntities.decode/1)
+
+    uri_smart_tag = ~r/"%3C%25.*?%25%3E"/
+    Regex.replace(uri_smart_tag, markdown, &URI.decode/1)
   end
 
   defp do_restore_smart_tags(markdown, _), do: markdown

--- a/test/engine_test.exs
+++ b/test/engine_test.exs
@@ -365,6 +365,51 @@ defmodule PhoenixMarkdown.EngineTest do
 
   end
 
+  test "compile a smart template with smart tags turned on with :all and percent-encoded tags" do
+    Mix.Config.persist(phoenix_markdown: [earmark: %Earmark.Options{}])
+    Mix.Config.persist(phoenix_markdown: [server_tags: :all])
+
+    data =
+      "test/fixtures/templates/view_test/my_app/page/smart_sample_links.html.md"
+      |> Engine.compile("smart_sample_links.html")
+
+    assert data ==
+             {:safe,
+              [
+                {:|, [],
+                 [
+                   {:__block__, [],
+                    [
+                      {:=, [],
+                       [
+                         {:tmp1, [], Phoenix.HTML.Engine},
+                         [
+                           {:|, [],
+                            [
+                              {:__block__, [],
+                               [
+                                 {:=, [],
+                                  [
+                                    {:tmp2, [], Phoenix.HTML.Engine},
+                                    [
+                                      {:|, [],
+                                       ["", "<h2>Smart Enough For Links</h2>\n<p><a href=\""]}
+                                    ]
+                                  ]},
+                                 "foo",
+                                 {:tmp2, [], Phoenix.HTML.Engine}
+                               ]},
+                              "\">foo</a>\n<a href=\""
+                            ]}
+                         ]
+                       ]},
+                      [{:|, [], [{:tmp1, [], Phoenix.HTML.Engine}, "bar"]}]
+                    ]},
+                   "\">bar</a>\n<a href=\"<% \"baz\" %>\">baz</a>\n<a href=\"\">foobar</a>\nfin</p>\n"
+                 ]}
+              ]}
+  end
+
   # ============================================================================
   # smart tags via :only tag
 

--- a/test/fixtures/templates/view_test/my_app/page/smart_sample_links.html.md
+++ b/test/fixtures/templates/view_test/my_app/page/smart_sample_links.html.md
@@ -1,0 +1,7 @@
+## Smart Enough For Links
+
+[foo](<% "foo" %>)
+[bar](<%= "bar" %>)
+[baz](<%% "baz" %>)
+[foobar](<%# "foobar" %>)
+fin


### PR DESCRIPTION
Content inside URI's is percent-encoded rather than HTML-encoded by
Earmark. In practice, this means that server tags inside links do not
work. Since Earmark doesn't prettify URI strings, this is independent of
smartypants processing. This is very similar to PR #9.

I further extended `do_handle_smart_tags` to replace all percent-encoded
server tags (inside URI strings) in addition to HTML-encoded server
tags. I also added a new test and fixture to make sure everything works.

This should resolve issue #8 