### PR TITLE
Prevent "current application does not depend on" compile warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PhoenixMarkdown.Mixfile do
   use Mix.Project
 
-  @version "1.0.3"
+  @version "1.0.4"
   @github "https://github.com/boydm/phoenix_markdown"
   @blog_post "https://medium.com/@boydm/markdown-templates-in-phoenix-25721a3bc682"
 
@@ -31,7 +31,7 @@ defmodule PhoenixMarkdown.Mixfile do
   end
 
   def application do
-    [applications: [:phoenix]]
+    [extra_applications: [:phoenix]]
   end
 
   defp deps do


### PR DESCRIPTION
Uses the :extra_applications key in mix.exs
Exposes dependencies correctly in mix.exs to prevent these warnings:

```
warning: Earmark.as_html!/2 defined in application :earmark is used by the current application but the current application does not depend on :earmark. To fix this, you must do one of:

  1. If :earmark is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :earmark is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :earmark, you may optionally skip this warning by adding [xref: [exclude: [Earmark]]] to your "def project" in mix.exs

  lib/phoenix_markdown/engine.ex:35: PhoenixMarkdown.Engine.compile/2

warning: HtmlEntities.decode/1 defined in application :html_entities is used by the current application but the current application does not depend on :html_entities. To fix this, you must do one of:

  1. If :html_entities is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :html_entities is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :html_entities, you may optionally skip this warning by adding [xref: [exclude: [HtmlEntities]]] to your "def project" in mix.exs

  lib/phoenix_markdown/engine.ex:58: PhoenixMarkdown.Engine.do_restore_smart_tags/2
```